### PR TITLE
Update sybase reference to 15.7

### DIFF
--- a/lib/CXC/Envs/Flight.pm
+++ b/lib/CXC/Envs/Flight.pm
@@ -30,7 +30,7 @@ my @EXPORT = qw(
 our $VERSION = '1.99';
 
 my %DEFAULT = (SKA => '/proj/sot/ska',
-               SYBASE => '/soft/SYBASE_OCS15',  # Eventually change back to /soft/sybase
+               SYBASE => '/soft/SYBASE15.7',  # Eventually change back to /soft/sybase
                SYBASE_OCS => 'OCS-15_0',  
               );
 
@@ -214,7 +214,7 @@ set unless already defined:
 
 The SYBASE and SYBASE_OCS variables are set (and will override any already defined in the shell ).
 
-    SYBASE         /soft/SYBASE_OCS15
+    SYBASE         /soft/SYBASE15.7
     SYBASE_OCS     OCS-15_0
 
 It also updates PATH, LD_LIBRARY_PATH, PERL5LIB, and PGPLOT_DIR to make the Ska

--- a/lib/CXC/Envs/Flight.pm
+++ b/lib/CXC/Envs/Flight.pm
@@ -27,7 +27,7 @@ my @EXPORT = qw(
 	
 );
 
-our $VERSION = '1.99';
+our $VERSION = '2.01';
 
 my %DEFAULT = (SKA => '/proj/sot/ska',
                SYBASE => '/soft/SYBASE15.7',  # Eventually change back to /soft/sybase


### PR DESCRIPTION
Update sybase reference to get version 15.7 of the library.  The reference was pointing to a 15.0 directory, and both 15.0 and 15.5 versions are deprecated and will be removed by arcops.
